### PR TITLE
Skip presenter lookup for anonymous classes

### DIFF
--- a/lib/oprah/presenter.rb
+++ b/lib/oprah/presenter.rb
@@ -87,6 +87,7 @@ module Oprah
 
         @@cache.fetch klass.name do
           klass.ancestors.map do |ancestor|
+            next unless ancestor.name
             (ancestor.name + "Presenter").safe_constantize
           end.compact.reverse
         end


### PR DESCRIPTION
For example if you have ancestors like this:

```
...
 ApplicationRecord::GeneratedAssociationMethods,
 #<#<Class:0x007f9b170f8c28>:0x007f9b170f8ca0>,
 ActiveRecord::Base,
...
```

you will receive an error `NoMethodError (undefined method '+' for nil:NilClass):` when trying to constantize presenter.