### PR TITLE
Fixed when one of klass's ancestors is eigen/singleton class

### DIFF
--- a/lib/oprah/presenter.rb
+++ b/lib/oprah/presenter.rb
@@ -87,7 +87,7 @@ module Oprah
 
         @@cache.fetch klass.name do
           klass.ancestors.map do |ancestor|
-            (ancestor.name + "Presenter").safe_constantize
+            (ancestor.name + "Presenter").safe_constantize if ancestor.name
           end.compact.reverse
         end
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -72,4 +72,13 @@ module Fixtures
     presents_many :comments
     presents_one :owner
   end
+
+  # EigenUser contains eigen class in ancestors list.
+  #
+  # > EigenUser.ancestors
+  # => [Fixtures::EigenUser, #<Module:0x007faa79b128f0>, Object, ... , Kernel, BasicObject]
+  #
+  class EigenUser
+    include Module.new
+  end
 end

--- a/test/oprah/presenter_test.rb
+++ b/test/oprah/presenter_test.rb
@@ -14,6 +14,10 @@ module Oprah
       assert_presented present(User.new)
     end
 
+    def test_present_with_eigenclass
+      assert_equal false, present(EigenUser.new).nil?
+    end
+
     def test_present_no_matching_presenter
       object = Object.new
       presented = present(object)


### PR DESCRIPTION
Mongoid generates singleton classes in ancestors list and it causes problems. This PR fixes it and tests included.